### PR TITLE
[Hacktoberfest] Support Symfony 3 version using serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "php": ">=5.3.9",
     "hafriedlander/phockito": "1.0.*",
     "apache/log4php": "2.3.*",
-    "symfony/serializer": "2.7.*",
-    "symfony/property-access": "2.7.*"
+    "symfony/serializer": "2.7.*|>=3.0 <4.0",
+    "symfony/property-access": "2.7.*|>=3.0 <4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This adds support in composer to install in Symfony 3 based installations.

The serializer should be almost the same and not errors BC I suppose.

This small PR is part of Hacktoberfest iniciative. Thanks!