### PR TITLE
Patch usage of libxml_disable_entity_loader() for PHP 8

### DIFF
--- a/src/main/php/com-realexpayments-remote-sdk/domain/payment/normaliser/CustomStringXmlEncoder.php
+++ b/src/main/php/com-realexpayments-remote-sdk/domain/payment/normaliser/CustomStringXmlEncoder.php
@@ -77,13 +77,21 @@ class CustomStringXmlEncoder extends SerializerAwareEncoder implements EncoderIn
 		}
 
 		$internalErrors  = libxml_use_internal_errors( true );
-		$disableEntities = libxml_disable_entity_loader( true );
+		$disableEntities = null;
+
+		if ( \PHP_VERSION_ID < 80000 || ( defined( 'LIBXML_VERSION' ) && \LIBXML_VERSION < 20900 ) ) {
+			$disableEntities = libxml_disable_entity_loader( true);
+		}
+
 		libxml_clear_errors();
 
 		$dom = new \DOMDocument();
 		$dom->loadXML( $data, LIBXML_NONET | LIBXML_NOBLANKS );
 
-		libxml_use_internal_errors( $internalErrors );
+		if ( \PHP_VERSION_ID < 80000 || ( defined( 'LIBXML_VERSION' ) && \LIBXML_VERSION < 20900 ) ) {
+			libxml_use_internal_errors( $internalErrors );
+		}
+
 		libxml_disable_entity_loader( $disableEntities );
 
 		if ( $error = libxml_get_last_error() ) {

--- a/src/main/php/com-realexpayments-remote-sdk/domain/payment/normaliser/CustomStringXmlEncoder.php
+++ b/src/main/php/com-realexpayments-remote-sdk/domain/payment/normaliser/CustomStringXmlEncoder.php
@@ -88,11 +88,11 @@ class CustomStringXmlEncoder extends SerializerAwareEncoder implements EncoderIn
 		$dom = new \DOMDocument();
 		$dom->loadXML( $data, LIBXML_NONET | LIBXML_NOBLANKS );
 
-		if ( \PHP_VERSION_ID < 80000 || ( defined( 'LIBXML_VERSION' ) && \LIBXML_VERSION < 20900 ) ) {
-			libxml_use_internal_errors( $internalErrors );
-		}
+		libxml_use_internal_errors( $internalErrors );
 
-		libxml_disable_entity_loader( $disableEntities );
+		if ( \PHP_VERSION_ID < 80000 || ( defined( 'LIBXML_VERSION' ) && \LIBXML_VERSION < 20900 ) ) {
+			libxml_disable_entity_loader( $disableEntities );
+		}
 
 		if ( $error = libxml_get_last_error() ) {
 			libxml_clear_errors();


### PR DESCRIPTION
Addresses a PHP 8 deprecated notice

reference: https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation